### PR TITLE
Fix initial lists loading

### DIFF
--- a/src/reviews.js
+++ b/src/reviews.js
@@ -62,7 +62,8 @@ export function currentWord(lists, listId) {
   );
 
   if (words.length > 0) {
-    return words[0][0]; // o_0
+    let pseudoRandomIndex = Math.floor(Math.random() * words.length);
+    return words[pseudoRandomIndex][0]; // o_0
   }
   return undefined;
 }

--- a/src/reviews.js
+++ b/src/reviews.js
@@ -30,7 +30,7 @@ export async function loadList(id) {
 
     let fresh = {};
 
-    if (local && !local[id]) {
+    if (!local || (local && !local[id])) {
       const url = `/data/${id}.json`;
       const response = await fetch(url);
       const upstream = await response.json();


### PR DESCRIPTION
When the local storage was empty (sign out + page refresh), the lists wouldn't be fetched at first. They would be fetched on second attempt but _after_ having shown the message that the review was done. 🙄 

**Unrelated**: I jumped on the opportunity to shuffle the pending words in order to avoid fatigue-induced biases when reviewing.