### PR TITLE
Fix downloads on iOS

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -9,7 +9,7 @@ export function download(filename, data) {
     elem.download = filename;
     document.body.appendChild(elem);
     elem.click();
-    window.URL.revokeObjectURL(elem.href);
+    // window.URL.revokeObjectURL(elem.href); // WebkitBlobResource error 1 on iOS 13.7
     document.body.removeChild(elem);
   }
 }


### PR DESCRIPTION
**Important**: Downloading JSON files on iOS is tricky anyway, but Safari allows to do it. (Brave doesn't for example as far as I could find out.)